### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-pipx-install-message.yml
+++ b/.github/workflows/create-pipx-install-message.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   post-comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kristiankunc/svs-core/security/code-scanning/1](https://github.com/kristiankunc/svs-core/security/code-scanning/1)

Add an explicit `permissions` block so the workflow token has only the scopes this workflow needs.

Best fix (without changing behavior): define workflow-level permissions near the top of `.github/workflows/create-pipx-install-message.yml`:
- `contents: read` (needed for checkout/read access)
- `pull-requests: write` (needed to create/update PR comments via the comment action)

This keeps functionality intact (commenting on PRs still works) while constraining token privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
