### PR TITLE
fix(web): Do not populate log retrieval error to the user

### DIFF
--- a/web/app/views/services.py
+++ b/web/app/views/services.py
@@ -253,7 +253,10 @@ def view_logs(request: HttpRequest, service_id: int):
     try:
         logs = service.get_logs()
     except Exception as e:
-        logs = f"Error fetching logs: {str(e)}"
+        get_logger(__name__).error(
+            f"Failed to fetch logs for service {service_id}: {str(e)}"
+        )
+        logs = "Error fetching logs. Please try again later."
 
     # Check if client wants JSON
     accept_header = request.headers.get("Accept", "")


### PR DESCRIPTION
Potential fix for [https://github.com/kristiankunc/svs-core/security/code-scanning/3](https://github.com/kristiankunc/svs-core/security/code-scanning/3)

To fix this safely, keep exception details out of user responses and only log them on the server.

Best fix in this file:
- In `view_logs` (`web/app/views/services.py`, around lines 253–257), replace the current `except` block so it:
  1. Logs the failure with context (`service_id`) and exception info.
  2. Sets `logs` to a generic message (no `str(e)`).
- Do not change response structure (`success`, `logs`, `timestamp`) to avoid functional/API breakage.

No new imports are required because `get_logger` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

BEGIN_COMMIT_OVERRIDE
fix(web): Do not populate log retrieval error to the user
END_COMMIT_OVERRIDE
