### PR TITLE
fix: Stop logging ENV variables

### DIFF
--- a/svs_core/shared/shell.py
+++ b/svs_core/shared/shell.py
@@ -113,7 +113,14 @@ def run_command(
 
         logger = get_logger(__name__)
 
-    logger.log(logging.DEBUG, f"Executing command: {command} with env: {exec_env}")
+    logger.log(
+        logging.DEBUG,
+        "Executing shell command (details redacted): user=%s, check=%s, has_env=%s, command_length=%s",
+        user,
+        check,
+        bool(exec_env),
+        len(command),
+    )
 
     result = subprocess.run(
         command, env=exec_env, check=check, capture_output=True, text=True, shell=True


### PR DESCRIPTION
Potential fix for [https://github.com/kristiankunc/svs-core/security/code-scanning/4](https://github.com/kristiankunc/svs-core/security/code-scanning/4)

General fix: never log raw command strings or full env maps from a generic shell execution helper, because callers may include secrets (passwords, tokens, keys). Log only safe metadata (for example, command length, whether env was provided, check/user flags), or a redacted form.

Best single fix in this codebase: update `svs_core/shared/shell.py` in `run_command` to replace the sensitive log line at current line ~116 with a sanitized metadata-only message that does not include `command` or `exec_env` contents. This one change addresses all 23 variants because they all converge at the same sink.

No behavior change to command execution is needed. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
